### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/resources/templates/Golden-AMI-Compliance-CFT.json
+++ b/resources/templates/Golden-AMI-Compliance-CFT.json
@@ -104,7 +104,7 @@
       ]]}
     },
     "Handler": "index.handler",
-    "Runtime": "nodejs8.10",
+    "Runtime": "nodejs10.x",
     "Timeout": "30",
     "Role": {"Fn::GetAtt": ["LambdaExecutionRole", "Arn"]}
   }


### PR DESCRIPTION
CloudFormation templates in golden-ami-pipeline-with-tenable-sample have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.